### PR TITLE
Add branch suffix in bump-version to allow multiple versioning simult…

### DIFF
--- a/.github/steps/bump-version/action.yml
+++ b/.github/steps/bump-version/action.yml
@@ -43,7 +43,7 @@ runs:
         commit-message: ${{ steps.bump.outputs.version }}
         committer: GitHub Actions Bot <noreply@holepunchto.com>
         author: GitHub Actions Bot <noreply@holepunchto.com>
-        branch: bump-version
+        branch: "bump-version-${{ steps.bump.outputs.version }}"
         delete-branch: true
         labels: ${{ inputs.labels }}
         title: ${{ steps.bump.outputs.version }}


### PR DESCRIPTION
…aneously

When building different versions simultaneously, the first PR will be conflicted by the second because the action is pushing in the same branch. This solves it by using different branch names.

