### PR TITLE
trigger-workflow-from-workflow

### DIFF
--- a/.github/steps/bump-deps/action.yml
+++ b/.github/steps/bump-deps/action.yml
@@ -35,6 +35,7 @@ runs:
       uses: peter-evans/create-pull-request@v7
       with:
         token: ${{ inputs.GITHUB_TOKEN }}
+        draft: always-true # require user to manually click "ready for review" for triggering another workflow, ref. https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
         commit-message: Bump deps
         committer: GitHub Actions Bot <noreply@holepunchto.com>
         author: GitHub Actions Bot <noreply@holepunchto.com>


### PR DESCRIPTION
# Context
- bump deps PR does not trigger CI to run test because the create-pull-request action cannot trigger another workflow
- ref: 
  - https://github.com/peter-evans/create-pull-request/issues/48
  - https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs

# Summary
- the simplest way is to listen on ready-to-review event when switching a draft PR to a ready PR
- hence, create-pull-request will always create draft PR by default

<img width="981" alt="image" src="https://github.com/user-attachments/assets/f8568765-b81c-49f1-a038-1e7d572130a7">

https://github.com/holepunchto/actions/pull/6
https://github.com/holepunchto/pear/pull/447