### PR TITLE
Add base node step with fixed action versions

### DIFF
--- a/node-base/action.yml
+++ b/node-base/action.yml
@@ -1,0 +1,11 @@
+name: Setup
+description: Node LTS + fixed action versions
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      with: { node-version: lts/* }
+    - run: npm install
+      shell: bash


### PR DESCRIPTION
This added shared step gives us a minimal Node action starting point with:
- latest LTS release of Node
- fixed commit versions of 3rd party actions (for reproducibility and security – tags can change etc)

To use, add as step in actions:

```yaml
    steps:
      - uses: holepunchto/actions/node-base@latest
      - run: npm install -g bare-runtime
      - run: npm test
```