### PR TITLE
Make macos_notarization_method optional in make-pear-app

### DIFF
--- a/make-pear-app/action.yml
+++ b/make-pear-app/action.yml
@@ -23,7 +23,8 @@ inputs:
     default: ''
   macos_notarization_method:
     description: 'Notarization method to use: appstore_connect or apple_id_password'
-    required: true
+    required: false
+    default: ''
   macos_apple_id:
     description: 'Apple ID email for notarization'
     required: false


### PR DESCRIPTION
It is required only on macOS. The validation step already enforces that.