### PR TITLE
Add shared `setup-*` actions

### DIFF
--- a/bare-base/action.yml
+++ b/bare-base/action.yml
@@ -1,9 +1,8 @@
-name: Setup Bare
-description: Setup required components for Bare projects
+name: Bare base
+description: Configure a Bare project
 
 runs:
   using: composite
   steps:
     - uses: holepunchto/actions/node-base@v1
-    - run: npm install --global bare-runtime
-      shell: bash
+    - uses: holepunchto/actions/setup-bare@v1

--- a/checkout/action.yml
+++ b/checkout/action.yml
@@ -1,0 +1,7 @@
+name: Checkout
+description: Checkout a git repository
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/node-base/action.yml
+++ b/node-base/action.yml
@@ -1,12 +1,10 @@
-name: Setup Node.js
-description: Setup Node.js LTS
+name: Node.js base
+description: Configure a Node.js project
 
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-      with:
-        node-version: lts/*
+    - uses: holepunchto/actions/checkout@v1
+    - uses: holepunchto/actions/setup-node@v1
     - run: npm install --ignore-scripts --allow-git=none
       shell: bash

--- a/pear-base/action.yml
+++ b/pear-base/action.yml
@@ -1,26 +1,24 @@
-name: Setup Pear
-description: Setup required components for Pear projects
+name: Pear base
+description: Configure a Pear project
 
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-      with:
-        node-version: lts/*
+    - uses: holepunchto/actions/checkout@v1
+    - uses: holepunchto/actions/setup-node@v1
 
     - name: Setup Pear
       run: npx -y pear
       shell: bash
 
-    - name: Add pear to PATH
-      shell: bash
+    - name: Add Pear to $PATH
       run: |
         case "$RUNNER_OS" in
           Linux)   echo "$HOME/.config/pear/bin" >> "$GITHUB_PATH" ;;
           macOS)   echo "$HOME/Library/Application Support/pear/bin" >> "$GITHUB_PATH" ;;
           Windows) echo "$USERPROFILE\\AppData\\Roaming\\pear\\bin" >> "$GITHUB_PATH" ;;
         esac
+      shell: bash
 
-    - run: npm install
+    - run: npm install --ignore-scripts --allow-git=none
       shell: bash

--- a/pear-base/action.yml
+++ b/pear-base/action.yml
@@ -4,8 +4,7 @@ description: Configure a Pear project
 runs:
   using: composite
   steps:
-    - uses: holepunchto/actions/checkout@v1
-    - uses: holepunchto/actions/setup-node@v1
+    - uses: holepunchto/actions/node-base@v1
 
     - name: Setup Pear
       run: npx -y pear
@@ -18,7 +17,4 @@ runs:
           macOS)   echo "$HOME/Library/Application Support/pear/bin" >> "$GITHUB_PATH" ;;
           Windows) echo "$USERPROFILE\\AppData\\Roaming\\pear\\bin" >> "$GITHUB_PATH" ;;
         esac
-      shell: bash
-
-    - run: npm install --ignore-scripts --allow-git=none
       shell: bash

--- a/setup-bare/action.yml
+++ b/setup-bare/action.yml
@@ -1,0 +1,8 @@
+name: Setup Bare
+description: Install and configure Bare
+
+runs:
+  using: composite
+  steps:
+    - run: npm install --global bare-runtime
+      shell: bash

--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -1,0 +1,9 @@
+name: Setup Node.js
+description: Install and configure Node.js LTS
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      with:
+        node-version: lts/*

--- a/setup-swift/action.yml
+++ b/setup-swift/action.yml
@@ -1,0 +1,7 @@
+name: Setup Swift
+description: Install and configure Swift
+
+runs:
+  using: composite
+  steps:
+    - uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2

--- a/swift-base/action.yml
+++ b/swift-base/action.yml
@@ -1,7 +1,8 @@
-name: Setup Swift
-description: Setup required components for Swift projects
+name: Swift base
+description: Configure a Swift project
 
 runs:
   using: composite
   steps:
-    - uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2
+    - uses: holepunchto/actions/checkout@v1
+    - uses: holepunchto/actions/setup-swift@v1


### PR DESCRIPTION
The existing `*-base` actions don't compose well as they run actions that should only run once per job, such as checking out from git. This PR instead factors out the setup steps into `setup-*` actions so that projects can use a single `*-base` action and then compose additional `setup-*` actions as needed. For https://github.com/holepunchto/hyperschema-swift, for example, we want to use `bare-base` followed by `setup-swift` as the project also needs access to Swift.