### PR TITLE
Disable release note generation

### DIFF
--- a/create-release/action.yml
+++ b/create-release/action.yml
@@ -17,7 +17,7 @@ runs:
     - id: pack
       run: echo "packages=$(ls *.tgz | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
       shell: bash
-    - run: gh release create ${{ github.ref_name }} ${{ steps.pack.outputs.packages }} --generate-notes
+    - run: gh release create ${{ github.ref_name }} ${{ steps.pack.outputs.packages }}
       env:
         GH_TOKEN: ${{ github.token }}
       shell: bash


### PR DESCRIPTION
GitHub does not support generating release notes from release branches, which our new release flow uses.