### PR TITLE
add config file for zizmor + allow ref-pin for holepunchto/actions

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,5 +1,0 @@
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        holepunchto/actions/*: ref-pin

--- a/setup-zizmor/action.yml
+++ b/setup-zizmor/action.yml
@@ -18,7 +18,8 @@ runs:
         if [ -n "${{ inputs.config }}" ]; then
           echo "path=${{ inputs.config }}" >> $GITHUB_OUTPUT
         else
-          echo "path=$GITHUB_ACTION_PATH/config.yml" >> $GITHUB_OUTPUT
+          cp "$GITHUB_ACTION_PATH/config.yml" "$GITHUB_WORKSPACE/.zizmor-config.yml"
+          echo "path=$GITHUB_WORKSPACE/.zizmor-config.yml" >> $GITHUB_OUTPUT
         fi
     - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
       with:

--- a/setup-zizmor/action.yml
+++ b/setup-zizmor/action.yml
@@ -18,8 +18,10 @@ runs:
         if [ -n "${{ inputs.config }}" ]; then
           echo "path=${{ inputs.config }}" >> $GITHUB_OUTPUT
         else
+          # Copy to workspace and use a relative path — zizmor-action runs zizmor from the
+          # workspace root, so a relative path works both on the host and inside a container.
           cp "$GITHUB_ACTION_PATH/config.yml" "$GITHUB_WORKSPACE/.zizmor-config.yml"
-          echo "path=$GITHUB_WORKSPACE/.zizmor-config.yml" >> $GITHUB_OUTPUT
+          echo "path=.zizmor-config.yml" >> $GITHUB_OUTPUT
         fi
     - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
       with:

--- a/setup-zizmor/action.yml
+++ b/setup-zizmor/action.yml
@@ -5,6 +5,9 @@ inputs:
   advanced-security:
     description: Upload results to GitHub Advanced Security
     default: false
+  config:
+    description: Path to a zizmor configuration file
+    default: ${{ github.action_path }}/config.yml
 
 runs:
   using: composite
@@ -13,3 +16,4 @@ runs:
       with:
         advanced-security: ${{ inputs.advanced-security }}
         version: 1.25.2
+        config: ${{ inputs.config }}

--- a/setup-zizmor/action.yml
+++ b/setup-zizmor/action.yml
@@ -7,7 +7,7 @@ inputs:
     default: false
   config:
     description: Path to a zizmor configuration file
-    default: ${{ github.action_path }}/config.yml
+    default: ./config.yml
 
 runs:
   using: composite

--- a/setup-zizmor/action.yml
+++ b/setup-zizmor/action.yml
@@ -7,13 +7,21 @@ inputs:
     default: false
   config:
     description: Path to a zizmor configuration file
-    default: ./config.yml
+    default: ''
 
 runs:
   using: composite
   steps:
+    - id: resolve-config-path
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.config }}" ]; then
+          echo "path=${{ inputs.config }}" >> $GITHUB_OUTPUT
+        else
+          echo "path=$GITHUB_ACTION_PATH/config.yml" >> $GITHUB_OUTPUT
+        fi
     - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
       with:
         advanced-security: ${{ inputs.advanced-security }}
         version: 1.25.2
-        config: ${{ inputs.config }}
+        config: ${{ steps.resolve-config-path.outputs.path }}

--- a/setup-zizmor/action.yml
+++ b/setup-zizmor/action.yml
@@ -14,9 +14,11 @@ runs:
   steps:
     - id: resolve-config-path
       shell: bash
+      env:
+        CONFIG: ${{ inputs.config }}
       run: |
-        if [ -n "${{ inputs.config }}" ]; then
-          echo "path=${{ inputs.config }}" >> $GITHUB_OUTPUT
+        if [ -n "$CONFIG" ]; then
+          echo "path=$CONFIG" >> $GITHUB_OUTPUT
         else
           # Copy to workspace and use a relative path — zizmor-action runs zizmor from the
           # workspace root, so a relative path works both on the host and inside a container.

--- a/setup-zizmor/action.yml
+++ b/setup-zizmor/action.yml
@@ -20,7 +20,7 @@ runs:
         if [ -n "$CONFIG" ]; then
           echo "path=$CONFIG" >> $GITHUB_OUTPUT
         else
-          # Copy to workspace and use a relative path — zizmor-action runs zizmor from the
+          # Copy to workspace and use a relative path - zizmor-action runs zizmor from the
           # workspace root, so a relative path works both on the host and inside a container.
           cp "$GITHUB_ACTION_PATH/config.yml" "$GITHUB_WORKSPACE/.zizmor-config.yml"
           echo "path=.zizmor-config.yml" >> $GITHUB_OUTPUT

--- a/setup-zizmor/config.yml
+++ b/setup-zizmor/config.yml
@@ -2,4 +2,4 @@ rules:
   unpinned-uses:
     config:
       policies:
-        holepunchto/*: ref-pin
+        holepunchto/actions/*: ref-pin

--- a/setup-zizmor/config.yml
+++ b/setup-zizmor/config.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        holepunchto/*: ref-pin


### PR DESCRIPTION
to test, add this to your action

```
- uses: holepunchto/actions/setup-zizmor@config-zizmor
```

Claude recommends the pattern of copying shared config file to local container of the repo running actions