### PR TITLE
Skip already published versions in workspaces mode

### DIFF
--- a/publish/action.yml
+++ b/publish/action.yml
@@ -17,11 +17,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: npm publish --ignore-scripts --tag $TAG ${{ case(inputs.workspaces == 'true', '--workspaces', '') }} ${{ case(inputs.include-workspace-root == 'true', '--include-workspace-root', '') }}
+    - run: node ${{ github.action_path }}/index.js
+      shell: bash
       env:
         NODE_AUTH_TOKEN: ${{ inputs.node-auth-token || env.NODE_AUTH_TOKEN }}
         TAG: ${{ inputs.tag }}
-      shell: bash
+        WORKSPACES: ${{ inputs.workspaces }}
+        INCLUDE_WORKSPACE_ROOT: ${{ inputs.include-workspace-root }}
     - uses: holepunchto/actions/create-release@v1
       with:
         workspaces: ${{ inputs.workspaces }}

--- a/publish/index.js
+++ b/publish/index.js
@@ -5,7 +5,10 @@ const includeWorkspaceRoot = process.env.INCLUDE_WORKSPACE_ROOT === 'true'
 const tag = process.env.TAG || 'latest'
 
 const npm = (args, options = {}) => spawnSync('npm', args, { stdio: 'inherit', ...options })
-const query = npm(['query', workspaces ? '.workspace' : '.', '--json'], { encoding: 'utf8', stdio: 'pipe' })
+const query = npm(['query', workspaces ? '.workspace' : '.', '--json'], {
+  encoding: 'utf8',
+  stdio: 'pipe'
+})
 
 if (query.status !== 0) {
   process.stderr.write(query.stderr)

--- a/publish/index.js
+++ b/publish/index.js
@@ -1,0 +1,32 @@
+const { spawnSync } = require('child_process')
+
+const workspaces = process.env.WORKSPACES === 'true'
+const includeWorkspaceRoot = process.env.INCLUDE_WORKSPACE_ROOT === 'true'
+const tag = process.env.TAG || 'latest'
+
+const npm = (args, options = {}) => spawnSync('npm', args, { stdio: 'inherit', ...options })
+const query = npm(['query', workspaces ? '.workspace' : '.', '--json'], { encoding: 'utf8', stdio: 'pipe' })
+
+if (query.status !== 0) {
+  process.stderr.write(query.stderr)
+  process.exit(query.status || 1)
+}
+
+const packages = JSON.parse(query.stdout)
+  .filter((pkg) => !pkg.private)
+  .filter((pkg) => includeWorkspaceRoot || pkg.location !== '.')
+
+for (const pkg of packages) {
+  const spec = `${pkg.name}@${pkg.version}`
+  const view = npm(['view', spec, 'version'], { stdio: 'ignore' })
+
+  if (view.status === 0) {
+    console.log(`Skipping already published ${spec}`)
+    continue
+  }
+
+  console.log(`Publishing ${spec}`)
+  const publish = npm(['publish', '--ignore-scripts', '--tag', tag, pkg.location])
+
+  if (publish.status !== 0) process.exit(publish.status || 1)
+}


### PR DESCRIPTION
`npm publish --workspace` tries to publish all packages and fails on ones that're already published. Ie. pushing new `lunte` fails the CI task when `vscode-lunte` isn't also new version.

Haven't tested it. Assisted by Codex