### PR TITLE
setup-swift: only install on Linux; use Xcode's toolchain on macOS

### DIFF
--- a/setup-swift/action.yml
+++ b/setup-swift/action.yml
@@ -4,4 +4,8 @@ description: Install and configure Swift
 runs:
   using: composite
   steps:
+    # Linux has no system Swift, so install it. macOS ships Swift with Xcode;
+    # installing a separate swift.org toolchain there skews the compiler against
+    # Xcode's SDK (e.g. Swift 6.1 compiler vs an Xcode 26.5 SDK built with 6.3.2).
     - uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2
+      if: ${{ runner.os == 'Linux' }}


### PR DESCRIPTION
`macos-latest` now ships Xcode 26.5, whose SDK is built with Swift 6.3.2. This action installs Swift via the pinned `swift-actions/setup-swift` (its `swift-version` defaults to `latest`, which resolves to 6.1 at the pinned commit). On macOS that standalone toolchain shadows Xcode's, so the 6.1 compiler is used against the 6.3.2 SDK and every build fails:

```
failed to build module 'Darwin'; this SDK is not supported by the compiler
(the SDK is built with 'Apple Swift version 6.3.2', while this compiler is
'Apple Swift version 6.1'). Please select a toolchain which matches the SDK.
```

This breaks darwin CI for every repo using the action (hrpc-swift, hyperschema-swift, bare-rpc-swift, compact-encoding-swift) as soon as the runner image updates.

Fix: install Swift only on Linux, which has no system Swift. On macOS use the preinstalled Xcode toolchain, whose compiler and SDK always match by construction and can't drift as versions move. Callers already skip this action on Windows.

Surfaced by hrpc-swift CI: https://github.com/holepunchto/hrpc-swift/actions/runs/28817789479/job/85461565371