### PR TITLE
Split publish into publish-npm; keep publish as an alias

### DIFF
--- a/publish-npm/action.yml
+++ b/publish-npm/action.yml
@@ -1,5 +1,5 @@
-name: Publish
-description: Publish to npm (alias for publish-npm)
+name: Publish to npm
+description: Create a GitHub release and publish to npm
 
 inputs:
   tag:
@@ -17,9 +17,12 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: holepunchto/actions/publish-npm@v1
+    - run: npm publish --ignore-scripts --tag $TAG ${{ case(inputs.workspaces == 'true', '--workspaces', '') }} ${{ case(inputs.include-workspace-root == 'true', '--include-workspace-root', '') }}
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token || env.NODE_AUTH_TOKEN }}
+        TAG: ${{ inputs.tag }}
+      shell: bash
+    - uses: holepunchto/actions/create-release@v1
       with:
-        tag: ${{ inputs.tag }}
         workspaces: ${{ inputs.workspaces }}
         include-workspace-root: ${{ inputs.include-workspace-root }}
-        node-auth-token: ${{ inputs.node-auth-token || env.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
Splits the single `publish` action into named, per-registry actions so we can add `publish-cargo`, `publish-pypi`, etc. as self-contained siblings later.

- **`publish-npm`** (new) — the canonical npm action: `npm publish` + `create-release`. Matches the `setup-node` / `setup-swift` naming convention.
- **`publish`** — now a thin backwards-compat alias that forwards to `publish-npm`. Existing `publish@v1` consumers are unchanged (identical inputs and behavior).

We deliberately avoided a `registry:` dispatcher toggle: composite `uses:` can't take an expression, so a router would have to re-declare every registry's inputs and grow with each one. Named siblings keep each action self-contained and the alias never grows.

The alias resolves `node-auth-token || env.NODE_AUTH_TOKEN` itself and forwards the concrete value, so callers who supply the token via ambient env keep working (the fallback stays one composite level below the caller, as before).

Note: `publish@v1` only resolves once the `v1` tag is advanced to a commit containing `publish-npm/` (same as the existing `create-release@v1` self-reference).