### PR TITLE
Skip `setup-socket` on Windows ARM64

### DIFF
--- a/setup-socket/action.yml
+++ b/setup-socket/action.yml
@@ -4,7 +4,12 @@ description: Install and configure Socket.dev
 runs:
   using: composite
   steps:
+    # socketdev/action#13 added win32-arm64 to the firewall distributions map in
+    # src/ but never rebuilt the committed dist/ bundle that action.yml runs, so
+    # it throws `Unsupported architecture win32-arm64` on every Windows ARM64
+    # runner. Skip it there until upstream ships the rebuilt bundle.
     - uses: socketdev/action@48bdbd2f664f69025e9cf90b34394d549c1e7c9e
+      if: ${{ runner.os != 'Windows' || runner.arch != 'ARM64' }}
       with:
         mode: firewall
         job-summary: errors


### PR DESCRIPTION
`socketdev/action` throws `Unsupported architecture win32-arm64` on every Windows ARM64 runner, so any repo using `node-base` or `bare-base` there fails during setup before it builds anything. bare-build's `main` has been red since #93 landed on Jul 15.

The cause is upstream. socketdev/action#13 added `win32-arm64` to the firewall distributions map in `src/tools/firewall.js`, but the committed `dist/` bundle that `action.yml` actually runs (`main: dist/main.js`) was never rebuilt. Its map still ends at `win32-x64`:

```
{"linux-x64":"linux-x86_64","linux-arm64":"linux-arm64","darwin-x64":"macos-x86_64",
 "darwin-arm64":"macos-arm64","win32-x64":"windows-x86_64.exe"}
```

so it throws before doing any work. `socketdev/action` main HEAD is that same commit, so there is nothing newer to pin to.

Skip the step on Windows ARM64 until upstream ships a rebuilt bundle.

Trade-off worth agreeing to explicitly: `npm install` on `windows-11-arm` runs without Socket Firewall until then. That arch currently gets no CI at all, so this is a net increase in coverage, but it is a deliberate, temporary supply-chain gap on one platform. The comment cites the upstream cause so the condition gets removed when the fix lands.

Note that `socketdev/action` has issues disabled and restricts PR creation, so reporting the `dist/` rebuild upstream needs to go through Socket support or their Discord rather than a pull request.
