### PR TITLE
Add setup-python and python-base actions

### DIFF
--- a/python-base/action.yml
+++ b/python-base/action.yml
@@ -1,0 +1,18 @@
+name: Python base
+description: Configure a Python project
+
+inputs:
+  python-version:
+    description: Python version to install
+    default: '3.12'
+
+runs:
+  using: composite
+  steps:
+    - uses: holepunchto/actions/checkout@v1
+    - uses: holepunchto/actions/setup-socket@v1
+    - uses: holepunchto/actions/setup-python@v1
+      with:
+        python-version: ${{ inputs.python-version }}
+    - run: sfw pip install -e '.[dev]'
+      shell: bash

--- a/setup-python/action.yml
+++ b/setup-python/action.yml
@@ -1,0 +1,14 @@
+name: Setup Python
+description: Install and configure Python
+
+inputs:
+  python-version:
+    description: Python version to install
+    default: '3.12'
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: ${{ inputs.python-version }}


### PR DESCRIPTION
Python analogs of `setup-node`/`node-base`.

- `setup-python`: wraps `actions/setup-python@<v5.6.0 sha>`, `python-version` input (default 3.12).
- `python-base`: checkout + setup-socket + setup-python + `sfw pip install -e '.[dev]'`. Mirrors `node-base` (Socket Firewall install); no dep-selection knobs, matching node/bare-base.

Confirmed in real CI against compact-encoding-python (matrix 3.10-3.13 green; `sfw pip install` ran).