### PR TITLE
Fall back to a direct install when `sfw` is unavailable

### DIFF
--- a/node-base/action.yml
+++ b/node-base/action.yml
@@ -25,7 +25,11 @@ runs:
       with:
         registry-url: ${{ inputs.registry-url }}
         scope: ${{ inputs.scope }}
-    - run: sfw npm install --ignore-scripts --foreground-scripts --allow-git=${{ case(inputs.allow-git == 'root', 'root', inputs.allow-git == 'all', 'all', 'none') }} ${{ case(inputs.force-install == 'true', '--force', '') }}
+    # setup-socket skips Socket Firewall on runners it has no binary for, so sfw
+    # is not always on PATH; install directly when it is absent.
+    - run: |
+        sfw=$(command -v sfw || true)
+        $sfw npm install --ignore-scripts --foreground-scripts --allow-git=${{ case(inputs.allow-git == 'root', 'root', inputs.allow-git == 'all', 'all', 'none') }} ${{ case(inputs.force-install == 'true', '--force', '') }}
       env:
         NODE_AUTH_TOKEN: ${{ inputs.node-auth-token || env.NODE_AUTH_TOKEN }}
       shell: bash

--- a/python-base/action.yml
+++ b/python-base/action.yml
@@ -14,5 +14,9 @@ runs:
     - uses: holepunchto/actions/setup-python@v1
       with:
         python-version: ${{ inputs.python-version }}
-    - run: sfw pip install -e '.[dev]'
+    # setup-socket skips Socket Firewall on runners it has no binary for, so sfw
+    # is not always on PATH; install directly when it is absent.
+    - run: |
+        sfw=$(command -v sfw || true)
+        $sfw pip install -e '.[dev]'
       shell: bash


### PR DESCRIPTION
Follow-up to #96, which was incomplete. Skipping `setup-socket` on Windows ARM64 stops the `Unsupported architecture win32-arm64` error, but `sfw` is then never installed, while `node-base` and `python-base` invoke it directly. The install step now fails later instead:

```
Run sfw npm install --ignore-scripts --foreground-scripts --allow-git=none
##[error]Process completed with exit code 127
```

Resolve `sfw` before using it, and install directly when it is absent:

```sh
sfw=$(command -v sfw || true)
$sfw npm install ...
```

Both call sites are covered (`node-base/action.yml:28`, `python-base/action.yml:17`). Verified under the same flags Actions uses for `shell: bash` (`bash --noprofile --norc -eo pipefail`): with `sfw` absent the installer runs directly and exits 0; with an `sfw` shim on PATH the command is wrapped exactly as before. `|| true` keeps `-e` from aborting when the lookup fails.

This keeps the firewall behaviour unchanged on every runner where it is available - the fallback only engages where `setup-socket` already skipped itself.
